### PR TITLE
[COOK-2085] Fix LWRP's nopasswd attribute's default value

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -25,7 +25,7 @@ attribute :group,      :kind_of => String,          :default => nil
 attribute :commands,   :kind_of => Array,           :default => ['ALL']
 attribute :host,       :kind_of => String,          :default => 'ALL'
 attribute :runas,      :kind_of => String,          :default => 'ALL'
-attribute :nopasswd,   :equal_to => [true, false],  :default => true
+attribute :nopasswd,   :equal_to => [true, false],  :default => false
 attribute :template,   :regex => /^[a-z_]+.erb$/,   :default => nil
 attribute :variables,  :kind_of => Hash,            :default => nil
 


### PR DESCRIPTION
Should be consistent with node attribute authorization/sudo/passwordless, which is also more secure default.

Ticket: http://tickets.opscode.com/browse/COOK-2085
