### PR TITLE
COOK-2119: Enhanced sudoer.erb to support multiple commands in a single sudo block

### DIFF
--- a/templates/default/sudoer.erb
+++ b/templates/default/sudoer.erb
@@ -1,4 +1,6 @@
 # This file is managed by Chef for <%= node['fqdn'] %>
 # Do NOT modify this file directly.
 
-<%= @sudoer %>  <%= @host %>=(<%= @runas %>) <%= 'NOPASSWD:' if @nopasswd %><%= @commands.join(' ') %>
+<% @commands.each do |command| -%>
+  <%= @sudoer %>  <%= @host %>=(<%= @runas %>) <%= 'NOPASSWD:' if @nopasswd %><%= command %>
+<% end -%>


### PR DESCRIPTION
I added a loop in sudoer.erb to print each listed command in a sudo 'commands' array on a single line in a sudoers.d file.
