### PR TITLE
Add solaris2 as supported OS.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ version           '2.0.4'
 
 recipe 'sudo', 'Installs sudo and configures /etc/sudoers'
 
-%w{redhat centos fedora ubuntu debian freebsd}.each do |os|
+%w{redhat centos fedora ubuntu debian freebsd solaris2}.each do |os|
   supports os
 end
 


### PR DESCRIPTION
I successfully smoke-tested this on the following OS:

```
                             Oracle Solaris 11 11/11 X86
    Copyright (c) 1983, 2011, Oracle and/or its affiliates.  All rights
  reserved.
                              Assembled 18 October 2011
```
