### PR TITLE
Fix example syntax in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ end
 ```
 
 ```ruby
-sudo 'tomcat'
+sudo 'tomcat' do
   template    'my_tomcat.erb' # local cookbook template
   variables   :cmds => ['/etc/init.d/tomcat restart']
 end


### PR DESCRIPTION
Just a small correction to the syntax in the README.  I believe this example should be a block?
