### PR TITLE
Add NexentaStor support

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ version           '2.0.4'
 
 recipe 'sudo', 'Installs sudo and configures /etc/sudoers'
 
-%w{redhat centos fedora ubuntu debian freebsd}.each do |os|
+%w{redhat centos fedora ubuntu debian freebsd solaris2}.each do |os|
   supports os
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,8 +17,12 @@
 # limitations under the License.
 #
 
-package 'sudo' do
-  action :install
+if node['kernel']['version'].include? "NexentaOS"
+  apt_package 'sudo'
+else
+  package 'sudo' do
+    action :install
+  end
 end
 
 if node['authorization']['sudo']['include_sudoers_d']


### PR DESCRIPTION
NexentaStor (http://nexentastor.org/) is an OpenSolaris derivative that uses the debian apt-get system for package management. On our system, I've explicitly defined the apt_package resource to get sudo to install properly.
