### PR TITLE
add setenv attribute support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Attributes
 - `node['authorization']['sudo']['groups']` - groups to enable sudo access (default: `[]`)
 - `node['authorization']['sudo']['users']` - users to enable sudo access (default: `[]`)
 - `node['authorization']['sudo']['passwordless']` - use passwordless sudo (default: `false`)
+- `node['authorization']['sudo']['setenv']` - allow sudo to setenv by passing -E flag (default: `false`)
 - `node['authorization']['sudo']['include_sudoers_d']` - include and manager `/etc/sudoers.d` (default: `false`)
 - `node['authorization']['sudo']['agent_forwarding']` - preserve `SSH_AUTH_SOCK` when sudoing (default: `false`)
 - `node['authorization']['sudo']['sudoers_defaults']` - Array of `Defaults` entries to configure in `/etc/sudoers`
@@ -186,6 +187,12 @@ case it is not already</td>
     <tr>
       <td>nopasswd</td>
       <td>supply a password to invoke sudo</td>
+      <td><tt>true</tt></td>
+      <td><tt>false</tt></td>
+    </tr>
+    <tr>
+      <td>setenv</td>
+      <td>allow sudo to accept -E flag for passing current user's environment</td>
       <td><tt>true</tt></td>
       <td><tt>false</tt></td>
     </tr>

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,7 @@
 default['authorization']['sudo']['groups']            = []
 default['authorization']['sudo']['users']             = []
 default['authorization']['sudo']['passwordless']      = false
+default['authorization']['sudo']['setenv']            = false
 default['authorization']['sudo']['include_sudoers_d'] = false
 default['authorization']['sudo']['agent_forwarding']  = false
 default['authorization']['sudo']['sudoers_defaults']  = ['!lecture,tty_tickets,!fqdn']

--- a/metadata.rb
+++ b/metadata.rb
@@ -39,6 +39,12 @@ attribute 'authorization/sudo/passwordless',
   :type => 'string',
   :default => 'false'
 
+attribute 'authorization/sudo/setenv',
+  :display_name => 'SetEnv Sudo',
+  :description => '',
+  :type => 'string',
+  :default => 'false'
+
 attribute 'authorization/sudo/include_sudoers_d',
   :display_name => 'Include sudoers.d',
   :description => 'Whether to create the sudoers.d includedir',

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -86,6 +86,7 @@ def render_sudoer
                     :host => new_resource.host,
                     :runas => new_resource.runas,
                     :nopasswd => new_resource.nopasswd,
+                    :setenv => new_resource.setenv,
                     :commands => new_resource.commands
       action        :nothing
     end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -47,6 +47,7 @@ template '/etc/sudoers' do
     :sudoers_groups => node['authorization']['sudo']['groups'],
     :sudoers_users => node['authorization']['sudo']['users'],
     :passwordless => node['authorization']['sudo']['passwordless'],
+    :setenv => node['authorization']['sudo']['setenv'],
     :include_sudoers_d => node['authorization']['sudo']['include_sudoers_d'],
     :agent_forwarding => node['authorization']['sudo']['agent_forwarding'],
     :sudoers_defaults => node['authorization']['sudo']['sudoers_defaults']

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -26,6 +26,7 @@ attribute :commands,   :kind_of => Array,           :default => ['ALL']
 attribute :host,       :kind_of => String,          :default => 'ALL'
 attribute :runas,      :kind_of => String,          :default => 'ALL'
 attribute :nopasswd,   :equal_to => [true, false],  :default => false
+attribute :setenv,     :equal_to => [true, false],  :default => false
 attribute :template,   :regex => /^[a-z_]+.erb$/,   :default => nil
 attribute :variables,  :kind_of => Hash,            :default => nil
 

--- a/templates/default/sudoer.erb
+++ b/templates/default/sudoer.erb
@@ -2,5 +2,5 @@
 # Do NOT modify this file directly.
 
 <% @commands.each do |command| -%>
-<%= @sudoer %>  <%= @host %>=(<%= @runas %>) <%= 'NOPASSWD:' if @nopasswd %><%= command %>
+<%= @sudoer %>  <%= @host %>=(<%= @runas %>) <%= 'NOPASSWD:' if @nopasswd %><%= 'SETENV:' if @setenv %><%= command %>
 <% end -%>

--- a/templates/default/sudoers.erb
+++ b/templates/default/sudoers.erb
@@ -12,15 +12,15 @@ Defaults      env_keep+=SSH_AUTH_SOCK
 root          ALL=(ALL) ALL
 
 <% @sudoers_users.each do |user| -%>
-<%= user %>   ALL=(ALL) <%= "NOPASSWD:" if @passwordless %>ALL
+<%= user %>   ALL=(ALL) <%= "NOPASSWD:" if @passwordless %><%= "SETENV:" if @setenv %>ALL
 <% end -%>
 
 # Members of the sysadmin group may gain root privileges
-%sysadmin     ALL=(ALL) <%= "NOPASSWD:" if @passwordless %>ALL
+%sysadmin     ALL=(ALL) <%= "NOPASSWD:" if @passwordless %><%= "SETENV:" if @setenv %>ALL
 
 <% @sudoers_groups.each do |group| -%>
 # Members of the group '<%= group %>' may gain root privileges
-%<%= group %> ALL=(ALL) <%= "NOPASSWD:" if @passwordless %>ALL
+%<%= group %> ALL=(ALL) <%= "NOPASSWD:" if @passwordless %><%= "SETENV:" if @setenv %>ALL
 <% end -%>
 
 <%= '#includedir /etc/sudoers.d' if @include_sudoers_d  %>


### PR DESCRIPTION
This adds a setenv variable, treated the same as the nopasswd/passwordless option.

The setenv option allows the given sudo command to accept the -E flag, which forwards the current user's environment to the sudo process.
