### PR TITLE
Removed the %sysadmin group

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ default_attributes(
 )
 ```
 
-**Note that the template for the sudoers file has the group "sysadmin" with ALL:ALL permission, though the group by default does not exist.**
-
 #### Sudoers Defaults
 
 Configure a node attribute,

--- a/templates/default/sudoers.erb
+++ b/templates/default/sudoers.erb
@@ -15,9 +15,6 @@ root          ALL=(ALL) ALL
 <%= user %>   ALL=(ALL) <%= "NOPASSWD:" if @passwordless %>ALL
 <% end -%>
 
-# Members of the sysadmin group may gain root privileges
-%sysadmin     ALL=(ALL) <%= "NOPASSWD:" if @passwordless %>ALL
-
 <% @sudoers_groups.each do |group| -%>
 # Members of the group '<%= group %>' may gain root privileges
 %<%= group %> ALL=(ALL) <%= "NOPASSWD:" if @passwordless %>ALL


### PR DESCRIPTION
Added a sudoers entry for the %sysadmin group may pose a security risk.
The group does not exist by default. A malicious user could create such
a group though. A better way would be to create the group entry
manually.

Signed-off-by: Haas, Christoph christoph.haas@coremedia.com
