### PR TITLE
11.6.0 compat in the templates

### DIFF
--- a/templates/default/sudoer.erb
+++ b/templates/default/sudoer.erb
@@ -1,4 +1,4 @@
-# This file is managed by Chef for <%= node['fqdn'] %>
+# This file is managed by Chef for <%= @node['fqdn'] %>
 # Do NOT modify this file directly.
 
 <% @commands.each do |command| -%>

--- a/templates/default/sudoers.erb
+++ b/templates/default/sudoers.erb
@@ -1,4 +1,4 @@
-# This file is managed by Chef for <%= node['fqdn'] %>
+# This file is managed by Chef for <%= @node['fqdn'] %>
 # Do NOT modify this file directly.
 
 <% @sudoers_defaults.each do |defaults| -%>


### PR DESCRIPTION
11.6.0 is not monkey patching Erubis::Context anymore. So we need to update templates to use node instance variable instead of node method.
