### PR TITLE
[COOK-3431] fix visudo file validation test

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -42,6 +42,7 @@ def validate_fragment!(resource)
 
   begin
     file.write(capture(resource))
+    file.rewind
 
     cmd = Mixlib::ShellOut.new("visudo -cf #{file.path}").run_command
     unless cmd.exitstatus == 0


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3431

the validate_fragment test isn't working properly, the Tempfile contents aren't written to disk prior to running visudo -cf #{file.path}

this change will write the file contents to disk and make file.read work to print out the file contents if there's an error

[broken run](https://gist.github.com/bhouse/e069539f5be683f2622d)

[fixed run](https://gist.github.com/bhouse/02534ebf6fc47bd5210e)
