### PR TITLE
[COOK-3653] changed template attribute to kind_of String

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -26,7 +26,7 @@ attribute :commands,   :kind_of => Array,           :default => ['ALL']
 attribute :host,       :kind_of => String,          :default => 'ALL'
 attribute :runas,      :kind_of => String,          :default => 'ALL'
 attribute :nopasswd,   :equal_to => [true, false],  :default => false
-attribute :template,   :regex => /^[a-z_]+.erb$/,   :default => nil
+attribute :template,   :kind_of => String,          :default => nil
 attribute :variables,  :kind_of => Hash,            :default => nil
 
 # Set default for the supports attribute in initializer since it is


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3653

The source attribute in template is kind_of String, here the corresponding template attribute is bound to a wrong regex.
