### PR TITLE
[COOK-4014] Move sysadmin group from template to attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-default['authorization']['sudo']['groups']            = []
+default['authorization']['sudo']['groups']            = ['sysadmin']
 default['authorization']['sudo']['users']             = []
 default['authorization']['sudo']['passwordless']      = false
 default['authorization']['sudo']['include_sudoers_d'] = false

--- a/templates/default/sudoers.erb
+++ b/templates/default/sudoers.erb
@@ -15,9 +15,6 @@ root          ALL=(ALL) ALL
 <%= user %> ALL=(ALL) <%= "NOPASSWD:" if @passwordless %>ALL
 <% end -%>
 
-# Members of the sysadmin group may gain root privileges
-%sysadmin ALL=(ALL) <%= "NOPASSWD:" if @passwordless %>ALL
-
 <% @sudoers_groups.each do |group| -%>
 # Members of the group '<%= group %>' may gain root privileges
 %<%= group %> ALL=(ALL) <%= "NOPASSWD:" if @passwordless %>ALL


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-4014

This makes it possible to deactivate the sysadmin group if case it's not needed/present.

``` ruby
node['authorization']['sudo']['groups'] = []
```
