### PR TITLE
Fix package installation failure issue.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,7 @@
 prefix = node['authorization']['sudo']['prefix']
 
 package 'sudo' do
-  not_if 'sudo -V'
+  not_if 'which sudo'
 end
 
 if node['authorization']['sudo']['include_sudoers_d']


### PR DESCRIPTION
The package statement will cause the Chef client run to fail if sudo is not installed as the not_if statement will exit with an error. Chicken or egg scenario :-)

In other words, the sudo cookbook fails if the sudo package/command is not yet installed on the system.
