### PR TITLE
Fix issue with "Defaults" line in sudoer.erb [COOK-4350]

### DIFF
--- a/templates/default/sudoer.erb
+++ b/templates/default/sudoer.erb
@@ -5,4 +5,6 @@
 <%= @sudoer %>  <%= @host %>=(<%= @runas %>) <%= 'NOPASSWD:' if @nopasswd %><%= command %>
 <% end -%>
 
+<% unless @defaults.empty? %>
 Defaults:<%= @sudoer %> <%= @defaults.join(',') %>
+<% end -%>


### PR DESCRIPTION
Only use "Defaults" line in sudoers.erb when defaults attribute is set
