### PR TITLE
[COOK-4612] Add support for the command alias (Cmnd_Alias) directive

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,7 @@ default['authorization']['sudo']['passwordless']      = false
 default['authorization']['sudo']['include_sudoers_d'] = false
 default['authorization']['sudo']['agent_forwarding']  = false
 default['authorization']['sudo']['sudoers_defaults']  = ['!lecture,tty_tickets,!fqdn']
+default['authorization']['sudo']['command_aliases']   = []
 
 case node['platform_family']
 when 'smartos'

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -88,6 +88,7 @@ def render_sudoer
                     :runas => new_resource.runas,
                     :nopasswd => new_resource.nopasswd,
                     :commands => new_resource.commands,
+                    :command_aliases => new_resource.command_aliases,
                     :defaults => new_resource.defaults
       action        :nothing
     end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -49,6 +49,7 @@ template "#{prefix}/sudoers" do
     :passwordless      => node['authorization']['sudo']['passwordless'],
     :include_sudoers_d => node['authorization']['sudo']['include_sudoers_d'],
     :agent_forwarding  => node['authorization']['sudo']['agent_forwarding'],
-    :sudoers_defaults  => node['authorization']['sudo']['sudoers_defaults']
+    :sudoers_defaults  => node['authorization']['sudo']['sudoers_defaults'],
+    :command_aliases   => node['authorization']['sudo']['command_aliases']
   )
 end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -20,15 +20,16 @@
 actions :install, :remove
 default_action :install
 
-attribute :user,       :kind_of => String,          :default => nil
-attribute :group,      :kind_of => String,          :default => nil
-attribute :commands,   :kind_of => Array,           :default => ['ALL']
-attribute :host,       :kind_of => String,          :default => 'ALL'
-attribute :runas,      :kind_of => String,          :default => 'ALL'
-attribute :nopasswd,   :equal_to => [true, false],  :default => false
-attribute :template,   :kind_of => String,          :default => nil
-attribute :variables,  :kind_of => Hash,            :default => nil
-attribute :defaults,   :kind_of => Array,           :default => []
+attribute :user,            :kind_of => String,           :default => nil
+attribute :group,           :kind_of => String,           :default => nil
+attribute :commands,        :kind_of => Array,            :default => ['ALL']
+attribute :host,            :kind_of => String,           :default => 'ALL'
+attribute :runas,           :kind_of => String,           :default => 'ALL'
+attribute :nopasswd,        :equal_to => [true, false],   :default => false
+attribute :template,        :kind_of => String,           :default => nil
+attribute :variables,       :kind_of => Hash,             :default => nil
+attribute :defaults,        :kind_of => Array,            :default => []
+attribute :command_aliases, :kind_of => Array,            :default => []
 
 # Set default for the supports attribute in initializer since it is
 # a 'reserved' attribute name
@@ -45,4 +46,5 @@ state_attrs :commands,
             :runas,
             :template,
             :user,
-            :variables
+            :variables,
+            :command_aliases

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -112,6 +112,24 @@ describe 'sudo::default' do
     end
   end
 
+  context "node['authorization']['sudo']['command_aliases']" do
+    let(:chef_run) do
+      ChefSpec::Runner.new do |node|
+        node.set['authorization']['sudo']['command_aliases'] =
+          [{ name: 'TESTA', command_list: ['/usr/bin/whoami'] }, { name: 'TeSTb', command_list: ['/usr/bin/ruby', '! /usr/bin/perl'] }]
+      end.converge(described_recipe)
+    end
+
+    it 'includes each command alias making sure they are upcased' do
+      expect(chef_run).to render_file('/etc/sudoers').with_content(
+        'Cmnd_Alias TESTA = /usr/bin/whoami'
+      )
+      expect(chef_run).to render_file('/etc/sudoers').with_content(
+        'Cmnd_Alias TESTB = /usr/bin/ruby, ! /usr/bin/perl'
+      )
+    end
+  end
+
   context 'sudoers.d' do
     let(:chef_run) do
       ChefSpec::Runner.new(platform: 'ubuntu', version: '12.04') do |node|

--- a/templates/default/sudoer.erb
+++ b/templates/default/sudoer.erb
@@ -1,6 +1,10 @@
 # This file is managed by Chef.
 # Do NOT modify this file directly.
 
+<% @command_aliases.each do |a| -%>
+Cmnd_Alias <%= a[:name].upcase %> = <%= a[:command_list].join(', ') %>
+<% end -%>
+
 <% @commands.each do |command| -%>
 <%= @sudoer %>  <%= @host %>=(<%= @runas %>) <%= 'NOPASSWD:' if @nopasswd %><%= command %>
 <% end -%>

--- a/templates/default/sudoers.erb
+++ b/templates/default/sudoers.erb
@@ -11,6 +11,10 @@ Defaults      env_keep+=SSH_AUTH_SOCK
 # User privilege specification
 root          ALL=(ALL) ALL
 
+<% @command_aliases.each do |a| -%>
+Cmnd_Alias <%= a[:name].upcase %> = <%= a[:command_list].join(', ') %>
+<% end -%>
+
 <% @sudoers_users.each do |user| -%>
 <%= user %> ALL=(ALL) <%= "NOPASSWD:" if @passwordless %>ALL
 <% end -%>

--- a/test/fixtures/cookbooks/fake/recipes/create.rb
+++ b/test/fixtures/cookbooks/fake/recipes/create.rb
@@ -10,3 +10,9 @@ end
 sudo 'bob' do
   user      'bob'
 end
+
+sudo 'alice' do
+  user            'alice'
+  command_aliases [{ name: 'STARTSSH', command_list: ['/etc/init.d/ssh start', '/etc/init.d/ssh restart', '! /etc/init.d/ssh stop'] }]
+  commands        ['STARTSSH']
+end

--- a/test/integration/create/bats/verify_created.bats
+++ b/test/integration/create/bats/verify_created.bats
@@ -16,3 +16,8 @@
 @test "it doesn't create defaults for specific sudo resource if no defaults are set (COOK-3409)" {
   sudo cat /etc/sudoers.d/bob | egrep -v "^Defaults:bob"
 }
+
+@test "it supports providing command aliases for sudo usage (COOK-4612)" {
+  sudo grep -E "^Cmnd_Alias STARTSSH = /etc/init.d/ssh start, /etc/init.d/ssh restart, \! /etc/init.d/ssh stop$" /etc/sudoers.d/alice
+  sudo grep -E "^alice  ALL=\(ALL\) STARTSSH$" /etc/sudoers.d/alice
+}


### PR DESCRIPTION
This adds support for building a set of command aliases to use in your
sudoers file.

The Cmnd_Alias directive, in short, allows you to specify a list of
commands to allow (or disallow). You then provide the name of the
command alias entry in your commands Array. The alias name should be
capitalized-alphanumeric and may contain underscores[1]. This does
upcase the name within the template to ensure (to some degree) that the
alias name is proper.

There are two ways you can use command aliases in the provided patch.
The first is to specify the command aliases in your node attributes:

``` Ruby
node.set['authorization']['sudo']['command_aliases'] =
    [{ name: 'ALIAS', command_list:['/usr/bin/whoami'] }]
```

Assuming you include the default recipe, this will add the command
alias to your /etc/sudoers file. This can be used by any users or
groups in that file, or any inherited installed sudoers.d files by
referencing the alias in their command list.

The second is within the sudo LWRP by specifying the aliases you want:

``` Ruby
sudo 'testgroup' do
  action :create
  group 'testgroup'
  command_aliases [{ name: 'TEST_CMD', command_list: ['/bin/true'] }]
  commands ['TEST_CMD']
end
```

When setting your command_aliases you want to provide a list of Hashes
with the following content:
- **name**:         The uppercased string you want to call the alias
- **command_list**: An Array of Strings (commands) you want to include
              in the alias while making sure to use the absolute path
              for the executables.

To then reference this alias, you want to add the capitalized name of
the alias to the user or group's command list.

In addition to the functionality, the tests were updated to check for
these new behaviors. As a note, it appears that the tests on master are
currently failing due to a new version of Rubocop. I will be working on
a patch to fix the Rubocop tests. However, tests for this branch will
fail if you were to run them and have a newer version of Rubocop.

[1] http://www.sudo.ws/sudoers.man.html#x416c6961736573
