### PR TITLE
Update README to reflect default sudoers groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The platform has a package named `sudo` and the `sudoers` file is `/etc/sudoers`
 
 Attributes
 ----------
-- `node['authorization']['sudo']['groups']` - groups to enable sudo access (default: `[]`)
+- `node['authorization']['sudo']['groups']` - groups to enable sudo access (default: `[ "sysadmin" ]`)
 - `node['authorization']['sudo']['users']` - users to enable sudo access (default: `[]`)
 - `node['authorization']['sudo']['passwordless']` - use passwordless sudo (default: `false`)
 - `node['authorization']['sudo']['include_sudoers_d']` - include and manager `/etc/sudoers.d` (default: `false`)


### PR DESCRIPTION
Per attributes/default.rb line 19, default is 'sysadmin'
