### PR TITLE
Munge file names in sudoers.d when the user has a dot in the name.

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -66,7 +66,7 @@ def render_sudoer
   if new_resource.template
     Chef::Log.debug('Template attribute provided, all other attributes ignored.')
 
-    resource = template "#{node['authorization']['sudo']['prefix']}/sudoers.d/#{new_resource.name}" do
+    resource = template "#{node['authorization']['sudo']['prefix']}/sudoers.d/#{sudo_filename}" do
       source new_resource.template
       owner 'root'
       group node['root_group']
@@ -77,7 +77,7 @@ def render_sudoer
   else
     sudoer = new_resource.user || "%#{new_resource.group}".squeeze('%')
 
-    resource = template "#{node['authorization']['sudo']['prefix']}/sudoers.d/#{new_resource.name}" do
+    resource = template "#{node['authorization']['sudo']['prefix']}/sudoers.d/#{sudo_filename}" do
       source 'sudoer.erb'
       cookbook 'sudo'
       owner 'root'
@@ -127,6 +127,12 @@ action :remove do
 end
 
 private
+
+# acording to the sudo man pages sudo will ignore files in an include dir that have a `.` or `~`
+# It is quite common for users to have a `.` in their login, so we will convert this to `__`
+def sudo_filename
+  new_resource.name.gsub(/\./, '__')
+end
 
 # Capture a template to a string
 def capture(template)

--- a/test/fixtures/cookbooks/fake/recipes/create.rb
+++ b/test/fixtures/cookbooks/fake/recipes/create.rb
@@ -11,6 +11,10 @@ sudo 'bob' do
   user 'bob'
 end
 
+sudo 'invalid.user' do
+  user 'bob'
+end
+
 sudo 'alice' do
   user 'alice'
   command_aliases [{ name: 'STARTSSH', command_list: ['/etc/init.d/ssh start', '/etc/init.d/ssh restart', '! /etc/init.d/ssh stop'] }]

--- a/test/integration/create/bats/verify_created.bats
+++ b/test/integration/create/bats/verify_created.bats
@@ -21,3 +21,7 @@
   sudo grep -E "^Cmnd_Alias STARTSSH = /etc/init.d/ssh start, /etc/init.d/ssh restart, \! /etc/init.d/ssh stop$" /etc/sudoers.d/alice
   sudo grep -E "^alice  ALL=\(ALL\) STARTSSH$" /etc/sudoers.d/alice
 }
+
+@test "it munges a user with a dot in it" {
+  test -f /etc/sudoers.d/invalid__user
+}


### PR DESCRIPTION
per the sudoers man page 
```
sudo will read each file in /etc/sudoers.d, skipping file names that end in ‘~’ or 
contain a ‘.’ character to avoid causing problems with package manager or editor 
temporary/backup files. 
```

This PR coerces the generated file name to replace a `.` with `__`  as it is common for users to have a dot in their names.

NOTE: failing integrations are failing on master as well. 