### PR TITLE
add lwrp support for only env_keep/env_reset

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -77,7 +77,7 @@ def render_sudoer
       action :nothing
     end
   else
-    sudoer = new_resource.user || "%#{new_resource.group}".squeeze('%')
+    sudoer = new_resource.user || ("%#{new_resource.group}".squeeze('%') if new_resource.group)
 
     resource = template "#{node['authorization']['sudo']['prefix']}/sudoers.d/#{sudo_filename}" do
       source 'sudoer.erb'

--- a/templates/default/sudoer.erb
+++ b/templates/default/sudoer.erb
@@ -14,7 +14,7 @@ Defaults    env_keep -= "<%= env_keep %>"
 <% end -%>
 
 <% @commands.each do |command| -%>
-<%= @sudoer %> <%= @host %>=(<%= @runas %>) <%= 'NOEXEC:' if @noexec %><%= 'NOPASSWD:' if @nopasswd %><%= 'SETENV:' if @setenv %><%= command %>
+<% if @sudoer %><%= @sudoer %> <%= @host %>=(<%= @runas %>) <%= 'NOEXEC:' if @noexec %><%= 'NOPASSWD:' if @nopasswd %><%= 'SETENV:' if @setenv %><%= command %><% end -%>
 <% end -%>
 
 <% unless @defaults.empty? %>

--- a/test/fixtures/cookbooks/test/recipes/create.rb
+++ b/test/fixtures/cookbooks/test/recipes/create.rb
@@ -43,3 +43,11 @@ sudo 'jane' do
   noexec true
   commands ['/usr/bin/less']
 end
+
+sudo 'rbenv' do
+  env_keep_add %w(PATH RBENV_ROOT RBENV_VERSION)
+end
+
+sudo 'java_home' do
+  env_keep_subtract ['JAVA_HOME']
+end

--- a/test/integration/create/default_spec.rb
+++ b/test/integration/create/default_spec.rb
@@ -63,3 +63,23 @@ end
 describe file('/etc/sudoers.d/__bob') do
   it { should be_file }
 end
+
+# supports setting only env_keep_add
+describe file('/etc/sudoers.d/rbenv') do
+  it { should be_file }
+  it { should be_owned_by 'root' }
+  its('group') { should eq 'root' }
+  its('mode') { should eq 288 }
+  its('content') { should match(/^Defaults    env_keep \+= "PATH"$/) }
+  its('content') { should match(/^Defaults    env_keep \+= "RBENV_ROOT"$/) }
+  its('content') { should match(/^Defaults    env_keep \+= "RBENV_VERSION"$/) }
+end
+
+# supports setting only env_keep_subtract
+describe file('/etc/sudoers.d/java_home') do
+  it { should be_file }
+  it { should be_owned_by 'root' }
+  its('group') { should eq 'root' }
+  its('mode') { should eq 288 }
+  its('content') { should match(/^Defaults    env_keep -= "JAVA_HOME"$/) }
+end


### PR DESCRIPTION
addressing issue #61 

This change makes the sudo lwrp more flexible by not requiring a user/group. More specifically it can now be used to create env_keeps and env_resets. Example:

```
sudo 'rbenv' do
  env_keep_add [ 'PATH', 'RBENV_ROOT', 'RBENV_VERSION' ]
end
```
