### PR TITLE
Add warning about 2.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ Bumping to 2.5.0
 [COOK-4350] - Fix issue with "Defaults" line in sudoer.erb
 
 ## v2.4.0 (2014-02-18)
+**BREAKING CHANGE**: The `sysadmin` group has been removed from the template. You will lose sudo access if:
+- You have users that depend on the sysadmin group for sudo access, and
+- You are overriding authorization.sudo.groups, but not including `sysadmin` in the list of groups
+
 ### Bug
 - **[COOK-4225](https://tickets.chef.io/browse/COOK-4225)** - Mac OS X: /etc/sudoers: syntax error when include_sudoers_d is true
 


### PR DESCRIPTION
Please add this warning about the 2.4.0 release to the changelog. The 2.4.0 release breaks compatibility on an edge case when `authorization.sudo.groups` is being overridden but `sysadmin` isn't included.

We were affected by this and our admins lost sudo rights on multiple nodes. It's easily correctable of course, but this is something that should be highly visible when people are upgrading cookbooks. Ideally this would have been a major version bump (according to SemVer) but it's too late for that.