### PR TITLE
make base sudoers file use attributes for env_keep_add and env_keep_s…

### DIFF
--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -150,6 +150,32 @@ describe 'sudo::default' do
     end
   end
 
+  context "node['authorization']['sudo']['env_keep_add']" do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['authorization']['sudo']['env_keep_add'] = ['TEST_ENV_ADD']
+      end.converge(described_recipe)
+    end
+    it 'adds environment variables to /etc/sudoers' do
+      expect(chef_run).to render_file('/etc/sudoers').with_content(
+        'Defaults    env_keep += "TEST_ENV_ADD"'
+      )
+    end
+  end
+
+  context "node['authorization']['sudo']['env_keep_subtract']" do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['authorization']['sudo']['env_keep_subtract'] = ['TEST_ENV_SUB']
+      end.converge(described_recipe)
+    end
+    it 'adds environment variables to /etc/sudoers' do
+      expect(chef_run).to render_file('/etc/sudoers').with_content(
+        'Defaults    env_keep -= "TEST_ENV_SUB"'
+      )
+    end
+  end
+
   context 'sudoers.d' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04') do |node|

--- a/templates/default/sudoers.erb
+++ b/templates/default/sudoers.erb
@@ -7,6 +7,12 @@ Defaults      <%= defaults %>
 <% if @agent_forwarding -%>
 Defaults      env_keep+=SSH_AUTH_SOCK
 <% end -%>
+<% @env_keep_add.each do |env_keep| -%>
+Defaults    env_keep += "<%= env_keep %>"
+<% end -%>
+<% @env_keep_subtract.each do |env_keep| -%>
+Defaults    env_keep -= "<%= env_keep %>"
+<% end -%>
 
 # User privilege specification
 root          ALL=(ALL) ALL


### PR DESCRIPTION
### Description

Makes it so the attributes env_keep_add and env_keep_subtract are actually used

https://github.com/chef-cookbooks/sudo/blob/master/attributes/default.rb#L28-L29

### Issues Resolved

Might resolve #61

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>