### PR TITLE
Sanitize file names in the :remove action for consistency

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -103,3 +103,5 @@ suites:
     run_list: test::default
   - name: create
     run_list: test::create
+  - name: remove
+    run_list: test::remove

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,3 +26,5 @@ suites:
     run_list: test::default
   - name: create
     run_list: test::create
+  - name: remove
+    run_list: test::remove

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,14 @@
 
 source 'https://rubygems.org'
 
+group :integration do
+  gem 'berkshelf'
+  gem 'test-kitchen'
+  gem 'kitchen-vagrant'
+  gem 'kitchen-dokken'
+  gem 'kitchen-inspec'
+end
+
 gem 'tomlrb'
 gem 'rake'
 gem 'stove'

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -124,7 +124,7 @@ end
 
 # Removes a user from the sudoers group
 action :remove do
-  resource = file "#{node['authorization']['sudo']['prefix']}/sudoers.d/#{new_resource.name}" do
+  resource = file "#{node['authorization']['sudo']['prefix']}/sudoers.d/#{sudo_filename}" do
     action :nothing
   end
   resource.run_action(:delete)

--- a/test/fixtures/cookbooks/test/recipes/remove.rb
+++ b/test/fixtures/cookbooks/test/recipes/remove.rb
@@ -1,0 +1,17 @@
+include_recipe 'test::default'
+include_recipe 'test::create'
+
+%w(
+  tomcat
+  bob
+  invalid.user
+  tilde-invalid~user
+  ~bob
+  alice
+  git
+  jane
+).each do |sudoer|
+  sudo sudoer do
+    action :remove
+  end
+end

--- a/test/integration/remove/default_spec.rb
+++ b/test/integration/remove/default_spec.rb
@@ -1,0 +1,14 @@
+%w(
+  tomcat
+  bob
+  invalid__user
+  tilde-invalid__user
+  __bob
+  alice
+  git
+  jane
+).each do |sudoer|
+  describe file("/etc/sudoers.d/#{sudoer}") do
+    it { should_not exist }
+  end
+end


### PR DESCRIPTION
### Description

This gets it into sync with the :install action so they'll be creating
and deleting the same sudoers.d files.

### Issues Resolved

- The output of an :install action is not always cleaned up by a corresponding :remove action

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Jonathan Hartman <j@p4nt5.com>