### PR TITLE
fixing command_aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ To use attributes for defining sudoers, set the attributes above on the node (or
   "default_attributes": {
     "authorization": {
       "sudo": {
-        "command_aliases": {
+        "command_aliases": [{
           "name": "TEST",
           "command_list": [
             "/usr/bin/ls",
             "/usr/bin/cat"
           ]
-        },
+        }],
         "custom_commands": {
           "users": [
             {


### PR DESCRIPTION
Signed-off-by: Jeremy J. Miller <jm@chef.io>

### Description

Fixing example in README.md.
`command_aliases` is an array of hashes, not a hash.

### Issues Resolved

n/a

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>