### PR TITLE
Make sure the package is installed at compile time versus waitin until execution phase.

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -115,7 +115,7 @@ action :install do
 
   package 'sudo' do
     not_if 'which sudo'
-  end
+  end.run_action(:install)
 
   unless ::File.exist?(target)
     sudoers_dir = directory target


### PR DESCRIPTION
### Description

Make sure the package is installed at compile time versus waiting until execution phase.

### Issues Resolved

Issue #103 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
