### PR TITLE
Remove sysadmin from default groups

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-default['authorization']['sudo']['groups']            = ['sysadmin']
+default['authorization']['sudo']['groups']            = []
 default['authorization']['sudo']['users']             = []
 default['authorization']['sudo']['passwordless']      = false
 default['authorization']['sudo']['setenv']            = false


### PR DESCRIPTION
### Description
sysadmins not necessary exist.  #97 supposed to take care of this.

### Issues Resolved

