### PR TITLE
Remove sysadmin from default sudo group

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-default['authorization']['sudo']['groups']            = ['sysadmin']
+default['authorization']['sudo']['groups']            = []
 default['authorization']['sudo']['users']             = []
 default['authorization']['sudo']['passwordless']      = false
 default['authorization']['sudo']['setenv']            = false


### PR DESCRIPTION
This is not only broke OS without sysadmin defined but looks like a security hole to predefine group with super power.

I understand there is an argument whether this should be on major version fix.  No matter it is on major or minor version, this will break people who assume sysadmin group exists on their system.   If people define authorizaton['sudo']['group'] = ['sysadmin'] in their node , role or environment, same privilege will appy and won't break them.

If this really need to go to major version change, at least keep this PR.  If we close this, the next major version will not catch this.   my  .02