### PR TITLE
Remove sysdadmin group from the default groups attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The default recipe installs the `sudo` package and configures the `/etc/sudoers`
 
 ## Attributes
 
-- `node['authorization']['sudo']['groups']` - groups to enable sudo access (default: `[ "sysadmin" ]`)
+- `node['authorization']['sudo']['groups']` - groups to enable sudo access (default: `[]`)
 - `node['authorization']['sudo']['users']` - users to enable sudo access (default: `[]`)
 - `node['authorization']['sudo']['passwordless']` - use passwordless sudo (default: `false`)
 - `node['authorization']['sudo']['include_sudoers_d']` - include and manage `/etc/sudoers.d` (default: `false`)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-default['authorization']['sudo']['groups']            = ['sysadmin']
+default['authorization']['sudo']['groups']            = []
 default['authorization']['sudo']['users']             = []
 default['authorization']['sudo']['passwordless']      = false
 default['authorization']['sudo']['setenv']            = false


### PR DESCRIPTION
We shouldn't be setting anything here out of the box. If users want this they can set it themselves. This will be a major version bump.

Signed-off-by: Tim Smith <tsmith@chef.io>