### PR TITLE
Enable sudoers.d out of the box on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The default recipe installs the `sudo` package and configures the `/etc/sudoers`
 - `node['authorization']['sudo']['groups']` - groups to enable sudo access (default: `[ "sysadmin" ]`)
 - `node['authorization']['sudo']['users']` - users to enable sudo access (default: `[]`)
 - `node['authorization']['sudo']['passwordless']` - use passwordless sudo (default: `false`)
-- `node['authorization']['sudo']['include_sudoers_d']` - include and manage `/etc/sudoers.d` (default: `false`)
+- `node['authorization']['sudo']['include_sudoers_d']` - include and manage `/etc/sudoers.d` (default: `true` on Linux systems. Note: older / EOL distros do not support this feature)
 - `node['authorization']['sudo']['agent_forwarding']` - preserve `SSH_AUTH_SOCK` when sudoing (default: `false`)
 - `node['authorization']['sudo']['sudoers_defaults']` - Array of `Defaults` entries to configure in `/etc/sudoers`
 - `node['authorization']['sudo']['setenv']` - Whether to permit preserving of environment with `sudo -E` (default: `false`)
@@ -187,9 +187,10 @@ node.default['authorization']['sudo']['sudoers_defaults'] = [
 
 ### Sudo Resource
 
-**Note** Sudo version 1.7.2 or newer is required to use the sudo LWRP as it relies on the "#includedir" directive introduced in version 1.7.2. The recipe does not enforce installing the version. To use this LWRP, set `node['authorization']['sudo']['include_sudoers_d']` to `true`.
+**Note** Sudo version 1.7.2 or newer is required to use the sudo LWRP as it relies on the "#includedir" directive introduced in version 1.7.2\. The recipe does not enforce installing the version. Supported releases of Ubuntu, Debian and RHEL (6+) all support this feature.
 
 There are two ways for rendering a sudoer-fragment using this LWRP:
+
 1. Using the built-in template
 2. Using a custom, cookbook-level template
 

--- a/README.md
+++ b/README.md
@@ -134,21 +134,6 @@ node.default['authorization']['sudo']['sudoers_defaults'] = [
 ]
 ```
 
-_RHEL family 5.x_ The version of sudo in RHEL 5 may not support `+=`, as used in `env_keep`, so its a single string.
-
-```ruby
-node.default['authorization']['sudo']['sudoers_defaults'] = [
-  '!visiblepw',
-  'env_reset',
-  'env_keep = "COLORS DISPLAY HOSTNAME HISTSIZE INPUTRC KDEDIR \
-               LS_COLORS MAIL PS1 PS2 QTDIR USERNAME \
-               LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION \
-               LC_MEASUREMENT LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC \
-               LC_PAPER LC_TELEPHONE LC_TIME LC_ALL LANGUAGE LINGUAS \
-               _XKB_CHARSET XAUTHORITY"'
-]
-```
-
 _RHEL family 6.x_
 
 ```ruby

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,7 @@ default['authorization']['sudo']['groups']            = ['sysadmin']
 default['authorization']['sudo']['users']             = []
 default['authorization']['sudo']['passwordless']      = false
 default['authorization']['sudo']['setenv']            = false
-default['authorization']['sudo']['include_sudoers_d'] = false
+default['authorization']['sudo']['include_sudoers_d'] = node['os'] == 'linux' ? true : false
 default['authorization']['sudo']['agent_forwarding']  = false
 default['authorization']['sudo']['sudoers_defaults']  = ['!lecture,tty_tickets,!fqdn']
 default['authorization']['sudo']['command_aliases']   = []

--- a/files/README
+++ b/files/README
@@ -1,17 +1,6 @@
-#
-# As of Debian version 1.7.2p1-1, the default /etc/sudoers file created on
-# installation of the package now includes the directive:
-#
-#       #includedir /etc/sudoers.d
-#
 # This will cause sudo to read and parse any files in the /etc/sudoers.d
 # directory that do not end in '~' or contain a '.' character.
 #
 # Note that there must be at least one file in the sudoers.d directory (this
 # one will do), and all files in this directory should be mode 0440.
-#
-# Note also, that because sudoers contents can vary widely, no attempt is
-# made to add this directive to existing sudoers files on upgrade.  Feel free
-# to add the above directive to the end of your /etc/sudoers file to enable
-# this functionality for existing installations if you wish!
 #

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,4 +5,6 @@ RSpec.configure do |config|
   config.color = true               # Use color in STDOUT
   config.formatter = :documentation # Use the specified formatter
   config.log_level = :error         # Avoid deprecation notice SPAM
+  config.platform = 'ubuntu'
+  config.version = '16.04'
 end

--- a/test/fixtures/cookbooks/test/attributes/default.rb
+++ b/test/fixtures/cookbooks/test/attributes/default.rb
@@ -4,6 +4,3 @@ default['authorization']['sudo']['users'] = %w(vagrant root)
 
 # Make sure sudo is passwordless for tests
 default['authorization']['sudo']['passwordless'] = true
-
-# Include sudoers.d
-default['authorization']['sudo']['include_sudoers_d'] = true

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,21 +1,26 @@
-describe file('/etc/sudoers.d') do
-  it { should be_directory }
-  it { should be_owned_by 'root' }
-  its('group') { should eq 'root' }
-  its('mode') { should eq 493 }
+if os.linux?
+  describe file('/etc/sudoers') do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    its('group') { should eq 'root' }
+    its('mode') { should cmp '0440' }
+  end
+
+  describe directory('/etc/sudoers.d') do
+    it { should be_owned_by 'root' }
+    its('group') { should eq 'root' }
+    its('mode') { should cmp '0755' }
+  end
+else
+  describe directory('/etc/sudoers.d') do
+    it { should_not exist }
+  end
 end
 
 describe file('/etc/sudoers.d/README') do
   it { should be_file }
   it { should be_owned_by 'root' }
   its('group') { should eq 'root' }
-  its('mode') { should eq 288 }
-  its('content') { should match(/As of Debian version/) }
-end
-
-describe file('/etc/sudoers') do
-  it { should be_file }
-  it { should be_owned_by 'root' }
-  its('group') { should eq 'root' }
-  its('mode') { should eq 288 }
+  its('mode') { should cmp '0440' }
+  its('content') { should match(/This will cause sudo to read and parse any files/) }
 end


### PR DESCRIPTION
It's support on RHEL 6+, Debian 7+, all current Ubuntu releases, and Fedora. It should be the out of the box experience as it enables the resource we ship here.  This will be part of a major version bump.