### PR TITLE
Improve visudo path resolution.

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -46,7 +46,11 @@ def validate_fragment!(resource)
     file.write(capture(resource))
     file.rewind
 
-    cmd = Mixlib::ShellOut.new("visudo -cf #{file.path}").run_command
+    cmd = Mixlib::ShellOut.new("visudo -cf #{file.path}")
+    cmd.environment['PATH'] = "/usr/sbin:#{ENV['PATH']}" if platform_family?('suse')
+    cmd.environment['PATH'] = "/usr/local/sbin:#{ENV['PATH']}" if platform_family?('solaris2')
+    cmd.environment['PATH'] = "#{new_resource.visudo_path}:#{ENV['PATH']}" unless new_resource.visudo_path.nil?
+    cmd.run_command
     unless cmd.exitstatus == 0
       Chef::Log.error("Fragment validation failed: \n\n")
       Chef::Log.error(file.read)

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -34,6 +34,7 @@ attribute :command_aliases,   kind_of: Array,            default: []
 attribute :setenv,            equal_to: [true, false],   default: false
 attribute :env_keep_add,      kind_of: Array,            default: []
 attribute :env_keep_subtract, kind_of: Array,            default: []
+attribute :visudo_path,       kind_of: String,           default: nil
 
 state_attrs :commands,
             :group,


### PR DESCRIPTION
### Description
Added a new `visudo_path` attribute to the sudo resource to allow users to specify the installed path of visudo.

In addition, the setting for the PATH environment variable on SLES and Solaris does not include the sbin path in which the visudo command is installed. This ensures the correct path value is inserted into the
PATH environment variable automatically before executing the command.

### Issues Resolved

Fixes #116

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
