### PR TITLE
New attribute for defining /etc/sudoers.d mode

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,6 +22,7 @@ default['authorization']['sudo']['users']             = []
 default['authorization']['sudo']['passwordless']      = false
 default['authorization']['sudo']['setenv']            = false
 default['authorization']['sudo']['include_sudoers_d'] = node['os'] == 'linux' ? true : false
+default['authorization']['sudo']['sudoers_d_mode']    = '0755'
 default['authorization']['sudo']['agent_forwarding']  = false
 default['authorization']['sudo']['sudoers_defaults']  = ['!lecture,tty_tickets,!fqdn']
 default['authorization']['sudo']['command_aliases']   = []

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,7 +25,7 @@ end
 
 if node['authorization']['sudo']['include_sudoers_d']
   directory "#{prefix}/sudoers.d" do
-    mode '0755'
+    mode node['authorization']['sudo']['sudoers_d_mode']
     owner 'root'
     group node['root_group']
   end


### PR DESCRIPTION
Signed-off-by: michael.sgarbossa <michael.sgarbossa@cvshealth.com>

### Description

Adds new attribute to allow user-defined mode on the /etc/sudoers.d directory.  The default value is the same as the current setting.
```
default['authorization']['sudo']['sudoers_d_mode']    = '0755'
```

### Issues Resolved

#119 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
