### PR TITLE
add chef_version_for_provides

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -8,7 +8,7 @@
 #
 # Copyright:: 2011-2018, Bryan w. Berry
 # Copyright:: 2012-2018, Seth Vargo
-# Copyright:: 2015-2018, Chef Software, Inc.
+# Copyright:: 2015-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+chef_version_for_provides "< 14.0" if defined?(:chef_version_for_provides)
+resource_name :sudo
 
 # acording to the sudo man pages sudo will ignore files in an include dir that have a `.` or `~`
 # We convert either to `__`


### PR DESCRIPTION
disables wiring up the resource on chef >= 14.0 and avoids deprecation
warning.
