### PR TITLE
Metadata syntax issue cookbook failed in chef:12

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'sudo'
 maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
-description 'Installs sudo and configures /etc/sudoers'\
+description 'Installs sudo and configures /etc/sudoers'
 version '5.4.4'
 
 %w(aix amazon redhat centos fedora ubuntu debian freebsd mac_os_x oracle scientific zlinux suse opensuse opensuseleap).each do |os|


### PR DESCRIPTION
Signed-off-by: Amal Soman amalsoman10@gmail.com

### Description
I am using chef 12, where "sudo" resource is not available. I used this cookbook to achieve the same but failed due to syntax issue in metadata.rb

### Issues Resolved

Fix #138 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
