### PR TITLE
Enable unified_mode to appease Cookstyle

### DIFF
--- a/.delivery/project.toml
+++ b/.delivery/project.toml
@@ -1,1 +1,9 @@
-remote_file = "https://raw.githubusercontent.com/chef-cookbooks/community_cookbook_tools/master/delivery/project.toml"
+[local_phases]
+unit = "rspec spec/"
+lint = 'cookstyle --display-cop-names --extra-details'
+syntax = "echo syntax checking with foodcritic has been replaced with cookstyle. skipping"
+provision = "echo skipping"
+deploy = "echo skipping"
+smoke = "echo skipping"
+functional = "echo skipping"
+cleanup = "echo skipping"

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -11,6 +11,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@master
     - name: Run Chef Delivery
-      uses: actionshub/chef-delivery@master
+      uses: actionshub/chef-delivery@main
       env:
         CHEF_LICENSE: accept-no-persist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of the sudo cookbook.
 
+## Unreleased
+
+- Enable `unified_mode` for Chef 17 compatibility - [@detjensrobert](https://github.com/detjensrobert)
+- Fix Delivery CI - [@detjensrobert](https://github.com/detjensrobert)
+
 ## 5.4.6 (2020-06-08)
 
 - Support Chef Infra Client 16.2+  - [@tas50](https://github.com/tas50)

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -27,6 +27,8 @@ chef_version_for_provides '< 14.0' if respond_to?(:chef_version_for_provides)
 resource_name :sudo
 provides :sudo
 
+unified_mode true if respond_to?(:unified_mode)
+
 # acording to the sudo man pages sudo will ignore files in an include dir that have a `.` or `~`
 # We convert either to `__`
 property :filename, String, name_property: true, coerce: proc { |x| x.gsub(/[\.~]/, '__') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,6 @@ require 'chefspec/berkshelf'
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT
   config.formatter = :documentation # Use the specified formatter
-  config.log_level = :error         # Avoid deprecation notice SPAM
+  config.log_level = :warn
   config.platform = 'ubuntu'
 end


### PR DESCRIPTION
### Description

This resource is disabled on Chef 14+, but Cookstyle still wants it set.

Also fixes the Delivery CI flow (reading from a remote file no longer works)

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Robert Detjens <detjensrobert@osuosl.org>